### PR TITLE
fix: Refine salary display for visual stability

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,21 +1,27 @@
 document.addEventListener('DOMContentLoaded', () => {
     // DOM Elements
     const monthlySalaryInput = document.getElementById('monthlySalary');
-    const annualSalaryInput = document.getElementById('annualSalary'); // New
-    const paydayInput = document.getElementById('payday'); // New
+    const annualSalaryInput = document.getElementById('annualSalary');
+    const paydayInput = document.getElementById('payday');
     const startTimeInput = document.getElementById('startTime');
     const endTimeInput = document.getElementById('endTime');
     const saveSettingsButton = document.getElementById('saveSettings');
     const salaryDisplay = document.getElementById('salaryDisplay');
-    const monthSalarySoFarDisplay = document.getElementById('monthSalarySoFar'); // New
-    const timeUntilPaydayDisplay = document.getElementById('timeUntilPayday'); // New
+    const monthSalarySoFarDisplay = document.getElementById('monthSalarySoFar');
+    const timeUntilPaydayDisplay = document.getElementById('timeUntilPayday');
     const settingsArea = document.getElementById('settingsArea');
     const editSettingsButton = document.getElementById('editSettingsButton');
 
     // Interval Timers
-    let salaryInterval = null;
-    let monthSalaryInterval = null; // New
-    let paydayCountdownInterval = null; // New
+    let salaryInterval = null; // For 1-second calculation of today's salary
+    let uiUpdateInterval_salaryDisplay = null; // For 3-second UI update of today's salary
+    let monthSalaryInterval = null; // For 1-second calculation of month's salary
+    let uiUpdateInterval_monthSalaryDisplay = null; // For 3-second UI update of month's salary
+    let paydayCountdownInterval = null;
+
+    // Variables to store latest calculated values
+    let lastKnownAccumulatedSalaryToday = 0.00;
+    let lastKnownMonthSalarySoFar = 0.00;
 
     // --- Settings Management ---
     function saveSettings() {
@@ -50,12 +56,11 @@ document.addEventListener('DOMContentLoaded', () => {
         localStorage.setItem('monthlySalary', monthlySalary);
         localStorage.setItem('startTime', startTime);
         localStorage.setItem('endTime', endTime);
-        localStorage.setItem('payday', payday); // Save payday
+        localStorage.setItem('payday', payday);
 
         settingsArea.classList.add('hidden');
         editSettingsButton.classList.remove('hidden');
 
-        // Restart all calculations with new settings
         calculateAndDisplaySalary();
         calculateAndDisplayMonthSalarySoFar();
         updatePaydayCountdown();
@@ -65,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const monthlySalary = localStorage.getItem('monthlySalary');
         const startTime = localStorage.getItem('startTime');
         const endTime = localStorage.getItem('endTime');
-        const payday = localStorage.getItem('payday'); // Load payday
+        const payday = localStorage.getItem('payday');
 
         if (monthlySalary) {
             monthlySalaryInput.value = parseFloat(monthlySalary).toFixed(2);
@@ -112,88 +117,105 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Salary Calculation and Display (Today) ---
     function calculateAndDisplaySalary() {
         if (salaryInterval) clearInterval(salaryInterval);
+        if (uiUpdateInterval_salaryDisplay) clearInterval(uiUpdateInterval_salaryDisplay);
+
+        lastKnownAccumulatedSalaryToday = 0.00; // Reset
+        if (salaryDisplay) salaryDisplay.textContent = lastKnownAccumulatedSalaryToday.toFixed(2);
+
 
         const monthlySalary = parseFloat(localStorage.getItem('monthlySalary'));
         const startTimeString = localStorage.getItem('startTime');
         const endTimeString = localStorage.getItem('endTime');
 
         if (isNaN(monthlySalary) || !startTimeString || !endTimeString) {
-            salaryDisplay.textContent = '0.00';
+            if (salaryDisplay) salaryDisplay.textContent = '0.00';
             return;
         }
 
-        const now = new Date();
-        const currentDay = now.toISOString().split('T')[0];
+        const workingDaysPerMonth = 22; 
+        const dailySalary = monthlySalary / workingDaysPerMonth;
+        
+        const now = new Date(); // Should be static for this calculation instance's parameters
+        const currentDay = now.toISOString().split('T')[0]; // Or use now for these if they should be dynamic too
         const workStartTime = new Date(`${currentDay}T${startTimeString}`);
         const workEndTime = new Date(`${currentDay}T${endTimeString}`);
+        let totalWorkMillisecondsInDay = workEndTime.getTime() - workStartTime.getTime();
 
-        if (workEndTime <= workStartTime && !(endTimeString < startTimeString)) {
-            salaryDisplay.textContent = 'Error!';
-            return;
-        }
-
-        const workingDaysPerMonth = 22; // Assumption
-        const dailySalary = monthlySalary / workingDaysPerMonth;
-        let totalWorkMillisecondsInDay = workEndTime - workStartTime;
 
         if (endTimeString < startTimeString) { // Overnight shift
             totalWorkMillisecondsInDay += 24 * 60 * 60 * 1000;
         }
 
-        if (totalWorkMillisecondsInDay <= 0) {
-            salaryDisplay.textContent = 'Error!';
+        if (totalWorkMillisecondsInDay <= 0 ) { // Removed: && workEndTime <= workStartTime && !(endTimeString < startTimeString)
+             if (salaryDisplay) salaryDisplay.textContent = 'Error!'; // Check if salaryDisplay exists
             return;
         }
         const salaryPerMillisecond = dailySalary / totalWorkMillisecondsInDay;
 
-        function updateSalary() {
-            const currentTime = new Date();
-            let effectiveWorkStartTime = new Date(`${currentTime.toISOString().split('T')[0]}T${startTimeString}`);
-            let effectiveWorkEndTime = new Date(`${currentTime.toISOString().split('T')[0]}T${endTimeString}`);
+        function performSalaryCalculation() {
+            const currentTime = new Date(); // This 'now' is for the current moment of calculation
+            let effectiveWorkStartTime = new Date(currentTime.getFullYear(), currentTime.getMonth(), currentTime.getDate(), workStartTime.getHours(), workStartTime.getMinutes(), workStartTime.getSeconds());
+            let effectiveWorkEndTime = new Date(currentTime.getFullYear(), currentTime.getMonth(), currentTime.getDate(), workEndTime.getHours(), workEndTime.getMinutes(), workEndTime.getSeconds());
 
-            if (endTimeString < startTimeString) { // Overnight shift
-                if (currentTime.getHours() < new Date(`1970-01-01T${startTimeString}`).getHours()) {
+
+            if (endTimeString < startTimeString) { 
+                if (currentTime.getHours() < workStartTime.getHours()) { // If current time is e.g. 2 AM, and work started at 10 PM yesterday
                     effectiveWorkStartTime.setDate(effectiveWorkStartTime.getDate() - 1);
-                } else {
+                } else { // If current time is e.g. 11 PM, and work started at 10 PM today, end time is tomorrow
                     effectiveWorkEndTime.setDate(effectiveWorkEndTime.getDate() + 1);
                 }
             }
 
-            if (currentTime >= effectiveWorkStartTime && currentTime <= effectiveWorkEndTime) {
-                const elapsedMillisecondsToday = currentTime - effectiveWorkStartTime;
-                const accumulatedSalaryToday = elapsedMillisecondsToday * salaryPerMillisecond;
-                salaryDisplay.textContent = accumulatedSalaryToday.toFixed(2);
+            if (currentTime.getTime() >= effectiveWorkStartTime.getTime() && currentTime.getTime() <= effectiveWorkEndTime.getTime()) {
+                const elapsedMillisecondsToday = currentTime.getTime() - effectiveWorkStartTime.getTime();
+                lastKnownAccumulatedSalaryToday = elapsedMillisecondsToday * salaryPerMillisecond;
             } else {
-                if (currentTime < effectiveWorkStartTime) {
-                    salaryDisplay.textContent = '0.00';
-                } else if (currentTime > effectiveWorkEndTime) {
-                    const totalAccumulated = totalWorkMillisecondsInDay * salaryPerMillisecond;
-                    salaryDisplay.textContent = totalAccumulated.toFixed(2);
-                    if (salaryInterval) clearInterval(salaryInterval); // Stop once full day's salary is shown
+                if (currentTime.getTime() < effectiveWorkStartTime.getTime()) {
+                    lastKnownAccumulatedSalaryToday = 0.00;
+                } else if (currentTime.getTime() > effectiveWorkEndTime.getTime()) {
+                    lastKnownAccumulatedSalaryToday = totalWorkMillisecondsInDay * salaryPerMillisecond; // Show full daily salary
+                    if (salaryInterval) clearInterval(salaryInterval); 
+                    salaryInterval = null; // Mark as stopped
                 }
             }
         }
-        updateSalary();
-        salaryInterval = setInterval(updateSalary, 1000);
+
+        function updateSalaryDisplayUI() {
+            if (salaryDisplay) salaryDisplay.textContent = lastKnownAccumulatedSalaryToday.toFixed(2);
+            if (!salaryInterval && uiUpdateInterval_salaryDisplay) { // If calculation has stopped, stop UI updates too
+                clearInterval(uiUpdateInterval_salaryDisplay);
+                uiUpdateInterval_salaryDisplay = null;
+            }
+        }
+        
+        performSalaryCalculation(); // Initial calculation
+        updateSalaryDisplayUI(); // Initial UI update
+
+        salaryInterval = setInterval(performSalaryCalculation, 1000);
+        uiUpdateInterval_salaryDisplay = setInterval(updateSalaryDisplayUI, 3000);
     }
 
     // --- Salary Earned This Month ---
     function calculateAndDisplayMonthSalarySoFar() {
         if (monthSalaryInterval) clearInterval(monthSalaryInterval);
+        if (uiUpdateInterval_monthSalaryDisplay) clearInterval(uiUpdateInterval_monthSalaryDisplay);
+        
+        lastKnownMonthSalarySoFar = 0.00; // Reset
+        if(monthSalarySoFarDisplay) monthSalarySoFarDisplay.textContent = lastKnownMonthSalarySoFar.toFixed(2);
 
         const monthlySalary = parseFloat(localStorage.getItem('monthlySalary'));
         const startTimeString = localStorage.getItem('startTime');
         const endTimeString = localStorage.getItem('endTime');
 
         if (isNaN(monthlySalary) || !startTimeString || !endTimeString) {
-            monthSalarySoFarDisplay.textContent = '0.00';
+            if(monthSalarySoFarDisplay) monthSalarySoFarDisplay.textContent = '0.00';
             return;
         }
 
-        const workingDaysPerMonth = 22; // Assumption
+        const workingDaysPerMonth = 22;
         const dailySalary = monthlySalary / workingDaysPerMonth;
 
-        function updateMonthSalary() {
+        function performMonthSalaryCalculation() {
             const now = new Date();
             const year = now.getFullYear();
             const month = now.getMonth();
@@ -202,129 +224,128 @@ document.addEventListener('DOMContentLoaded', () => {
             let completedWorkdaysThisMonth = 0;
             for (let day = 1; day < todayDate; day++) {
                 const d = new Date(year, month, day);
-                if (d.getDay() >= 1 && d.getDay() <= 5) { // Monday to Friday
+                if (d.getDay() >= 1 && d.getDay() <= 5) { 
                     completedWorkdaysThisMonth++;
                 }
             }
             let salaryFromCompletedDays = completedWorkdaysThisMonth * dailySalary;
-
-            // Current day's contribution (if it's a workday)
             let salaryToday = 0;
             const currentDayOfWeek = now.getDay();
-            if (currentDayOfWeek >= 1 && currentDayOfWeek <= 5) { // Monday to Friday
-                let effectiveWorkStartTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), parseInt(startTimeString.split(':')[0]), parseInt(startTimeString.split(':')[1]));
-                let effectiveWorkEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), parseInt(endTimeString.split(':')[0]), parseInt(endTimeString.split(':')[1]));
+
+            if (currentDayOfWeek >= 1 && currentDayOfWeek <= 5) { // Is it a Workday?
+                const workStartTimeDate = new Date(`1970-01-01T${startTimeString}`); // For hour/minute extraction
+                const workEndTimeDate = new Date(`1970-01-01T${endTimeString}`); // For hour/minute extraction
+
+                let effectiveWorkStartTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), workStartTimeDate.getHours(), workStartTimeDate.getMinutes());
+                let effectiveWorkEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), workEndTimeDate.getHours(), workEndTimeDate.getMinutes());
                 
-                if (endTimeString < startTimeString) { // Overnight shift logic for today
-                    if (now.getHours() < new Date(`1970-01-01T${startTimeString}`).getHours()) { // After midnight, part of yesterday's shift start
-                         // This part is complex for "month salary so far" if shift spans midnight
-                         // For simplicity here, if current time is past midnight but part of a shift that started yesterday,
-                         // it counts towards *yesterday's* daily total which is already in completedWorkdaysThisMonth.
-                         // The current day's calculation will only apply if the shift starts and possibly ends today.
-                         // A more robust solution would track exact work segments.
-                    } else { // Shift started today, may end tomorrow
+                if (endTimeString < startTimeString) { // Overnight shift for *today's* segment
+                    if (now.getHours() < workStartTimeDate.getHours()) { 
+                        // This means we are past midnight, shift started yesterday.
+                        // For "month salary so far", the part of shift from yesterday is already in `salaryFromCompletedDays`.
+                        // We only care about the part from midnight *today* until `now` or `effectiveWorkEndTime` today.
+                        effectiveWorkStartTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0); // Start from midnight today
+                    } else { // Shift starts today and ends tomorrow
                         effectiveWorkEndTime.setDate(effectiveWorkEndTime.getDate() + 1);
                     }
                 }
 
-                if (now >= effectiveWorkStartTime && now <= effectiveWorkEndTime) {
-                    const totalWorkMillisecondsInDay = (effectiveWorkEndTime - effectiveWorkStartTime);
-                    const salaryPerMillisecondToday = dailySalary / totalWorkMillisecondsInDay;
-                    const elapsedMillisecondsToday = now - effectiveWorkStartTime;
-                    salaryToday = elapsedMillisecondsToday * salaryPerMillisecondToday;
-                } else if (now > effectiveWorkEndTime) {
-                    salaryToday = dailySalary; // Full day's salary if past work hours
+                if (now.getTime() >= effectiveWorkStartTime.getTime() && now.getTime() <= effectiveWorkEndTime.getTime()) {
+                    // Calculate total duration of *this specific segment* of the workday
+                    // (could be full day, or partial if overnight and started yesterday)
+                    const segmentDuration = effectiveWorkEndTime.getTime() - effectiveWorkStartTime.getTime();
+                    if (segmentDuration > 0) {
+                        const salaryPerMsForSegment = dailySalary / (workEndTimeDate.getTime() - workStartTimeDate.getTime() + (endTimeString < startTimeString ? 24*60*60*1000 : 0)); // Salary rate based on full shift
+                        const elapsedMsInSegment = now.getTime() - effectiveWorkStartTime.getTime();
+                        salaryToday = elapsedMsInSegment * salaryPerMsForSegment;
+                    }
+                } else if (now.getTime() > effectiveWorkEndTime.getTime()) {
+                    // If current time is past today's work segment end time
+                    if (effectiveWorkStartTime.getDate() === now.getDate() || // Shift started today
+                        (effectiveWorkStartTime.getDate() < now.getDate() && endTimeString < startTimeString) // Shift started yesterday and ended today
+                    ) {
+                         salaryToday = dailySalary;
+                    }
                 }
             }
-            
-            monthSalarySoFarDisplay.textContent = (salaryFromCompletedDays + salaryToday).toFixed(2);
+            lastKnownMonthSalarySoFar = salaryFromCompletedDays + salaryToday;
         }
-        updateMonthSalary();
-        monthSalaryInterval = setInterval(updateMonthSalary, 1000); // Update frequently
+
+        function updateMonthSalaryDisplayUI() {
+            if (monthSalarySoFarDisplay) monthSalarySoFarDisplay.textContent = lastKnownMonthSalarySoFar.toFixed(2);
+        }
+
+        performMonthSalaryCalculation(); // Initial calculation
+        updateMonthSalaryDisplayUI(); // Initial UI update
+
+        monthSalaryInterval = setInterval(performMonthSalaryCalculation, 1000);
+        uiUpdateInterval_monthSalaryDisplay = setInterval(updateMonthSalaryDisplayUI, 3000);
     }
 
     // --- Payday Countdown ---
     function updatePaydayCountdown() {
         if (paydayCountdownInterval) clearInterval(paydayCountdownInterval);
+        if(timeUntilPaydayDisplay) timeUntilPaydayDisplay.textContent = 'N/A';
+
 
         const paydaySetting = localStorage.getItem('payday');
         if (!paydaySetting) {
-            timeUntilPaydayDisplay.textContent = "Payday not set";
+            if(timeUntilPaydayDisplay) timeUntilPaydayDisplay.textContent = "Payday not set";
             return;
         }
-        const paydayDay = parseInt(paydaySetting); // This is the user's preferred day (e.g., 15, 30, 31)
+        const paydayDay = parseInt(paydaySetting);
 
         function countdown() {
             const now = new Date();
             let targetYear = now.getFullYear();
-            let targetMonth = now.getMonth(); // 0-indexed
+            let targetMonth = now.getMonth(); 
 
-            // Determine if we are aiming for this month's payday or next month's
-            if (now.getDate() > paydayDay || (now.getDate() === paydayDay && now.getTime() >= new Date(targetYear, targetMonth, paydayDay).getTime())) {
-                // If current day is past preferred payday OR (it's the preferred payday AND current time is past midnight of that day)
-                // then aim for next month.
-                targetMonth++;
-                if (targetMonth > 11) { // Month overflow
-                    targetMonth = 0;
-                    targetYear++;
-                }
-            }
+            let nextPaydayDateObj = new Date(targetYear, targetMonth, paydayDay, 0,0,0,0); // Target start of the day
 
-            // Calculate the actual number of days in the target month
-            const daysInTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
-            
-            // Determine the actual payday date, ensuring it's not beyond the last day of the month
-            const actualPaydayDate = Math.min(paydayDay, daysInTargetMonth);
-            
-            let nextPayday = new Date(targetYear, targetMonth, actualPaydayDate);
-            
-            // If, for some reason (e.g. payday was 29th, current month Feb, nextPayday becomes Feb 29th but it's not a leap year)
-            // the date got resolved to the next month (e.g. March 1st if Feb 29 doesn't exist),
-            // it means we should have picked the last valid day of targetMonth.
-            // The new Date(targetYear, targetMonth + 1, 0).getDate() above handles this correctly for `daysInTargetMonth`.
-            // So `actualPaydayDate` will be correct. `new Date(targetYear, targetMonth, actualPaydayDate)` should be fine.
-
-            const diff = nextPayday.getTime() - now.getTime(); // Ensure using getTime() for direct comparison
-
-            if (diff <= 0) { 
-                 // This case might occur if it's currently past the calculated payday time on the payday itself.
-                 // Or if the logic for advancing to next month didn't quite catch it.
-                 // To be safe, if diff is <=0, try to calculate for the *next* available payday.
-                 // This typically means advancing the month again.
-                targetMonth++;
+            if (now.getTime() >= nextPaydayDateObj.getTime()) { 
+                targetMonth++; 
                 if (targetMonth > 11) {
                     targetMonth = 0;
                     targetYear++;
                 }
-                const daysInNextTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
-                const actualNextPaydayDate = Math.min(paydayDay, daysInNextTargetMonth);
-                nextPayday = new Date(targetYear, targetMonth, actualNextPaydayDate);
-                
-                // Recalculate diff
-                const newDiff = nextPayday.getTime() - now.getTime();
-                if (newDiff <=0) {
-                    // If still non-positive, there's a deeper issue or it's truly the exact moment.
-                    timeUntilPaydayDisplay.textContent = "Processing Payday..."; // Or similar
-                    return;
-                }
-                 const days = Math.floor(newDiff / (1000 * 60 * 60 * 24));
-                 const hours = Math.floor((newDiff / (1000 * 60 * 60)) % 24);
-                 const minutes = Math.floor((newDiff / 1000 / 60) % 60);
-                 const seconds = Math.floor((newDiff / 1000) % 60);
-                 timeUntilPaydayDisplay.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
-
-            } else {
-                const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-                const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-                const minutes = Math.floor((diff / 1000 / 60) % 60);
-                const seconds = Math.floor((diff / 1000) % 60);
-                timeUntilPaydayDisplay.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
             }
+            
+            const daysInTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
+            const actualPaydayCalDay = Math.min(paydayDay, daysInTargetMonth);
+            let nextPayday = new Date(targetYear, targetMonth, actualPaydayCalDay, 0,0,0,0);
+            
+            // If the calculated nextPayday is still not in the future (e.g. today after adjustment was still today but time passed)
+            if (now.getTime() >= nextPayday.getTime()) {
+                 targetMonth = nextPayday.getMonth() + 1; 
+                 if (targetMonth > 11) {
+                    targetMonth = 0;
+                    targetYear = nextPayday.getFullYear() + 1;
+                 } else {
+                    targetYear = nextPayday.getFullYear();
+                 }
+                 const daysInFinalTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
+                 const actualFinalPaydayCalDay = Math.min(paydayDay, daysInFinalTargetMonth);
+                 nextPayday = new Date(targetYear, targetMonth, actualFinalPaydayCalDay, 0,0,0,0);
+            }
+
+
+            const diff = nextPayday.getTime() - now.getTime();
+
+            if (diff <= 0) { // Should ideally be future now
+                if(timeUntilPaydayDisplay) timeUntilPaydayDisplay.textContent = "Calculating next..."; 
+                return; // Wait for next tick to resolve, should be extremely rare
+            }
+
+            const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+            const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+            const minutes = Math.floor((diff / 1000 / 60) % 60);
+            const seconds = Math.floor((diff / 1000) % 60);
+
+            if(timeUntilPaydayDisplay) timeUntilPaydayDisplay.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
         }
-        countdown(); // Initial call
+        countdown();
         paydayCountdownInterval = setInterval(countdown, 1000);
     }
-
 
     // --- Event Listeners ---
     saveSettingsButton.addEventListener('click', saveSettings);
@@ -332,18 +353,27 @@ document.addEventListener('DOMContentLoaded', () => {
     editSettingsButton.addEventListener('click', () => {
         settingsArea.classList.remove('hidden');
         editSettingsButton.classList.add('hidden');
-        // Stop intervals when settings are opened
+        
+        // Clear all calculation and UI update intervals
         if (salaryInterval) clearInterval(salaryInterval);
+        if (uiUpdateInterval_salaryDisplay) clearInterval(uiUpdateInterval_salaryDisplay);
         if (monthSalaryInterval) clearInterval(monthSalaryInterval);
+        if (uiUpdateInterval_monthSalaryDisplay) clearInterval(uiUpdateInterval_monthSalaryDisplay);
         if (paydayCountdownInterval) clearInterval(paydayCountdownInterval);
-        salaryDisplay.textContent = '0.00';
-        monthSalarySoFarDisplay.textContent = '0.00';
-        timeUntilPaydayDisplay.textContent = 'N/A';
+        
+        salaryInterval = null; uiUpdateInterval_salaryDisplay = null;
+        monthSalaryInterval = null; uiUpdateInterval_monthSalaryDisplay = null;
+        paydayCountdownInterval = null;
+
+        if (salaryDisplay) salaryDisplay.textContent = '0.00';
+        if (monthSalarySoFarDisplay) monthSalarySoFarDisplay.textContent = '0.00';
+        if (timeUntilPaydayDisplay) timeUntilPaydayDisplay.textContent = 'N/A';
+        lastKnownAccumulatedSalaryToday = 0.00;
+        lastKnownMonthSalarySoFar = 0.00;
     });
 
     // --- Initial Load ---
     loadSettings();
-    // Initial calls to display data if settings are already stored
     if (localStorage.getItem('monthlySalary') && localStorage.getItem('startTime') && localStorage.getItem('endTime')) {
         calculateAndDisplaySalary();
         calculateAndDisplayMonthSalarySoFar();


### PR DESCRIPTION
This commit addresses your feedback regarding the visual distraction caused by rapidly updating salary figures.

- The "Current Accumulated Salary" and "Salary Earned This Month" displays now update their text content every 3 seconds.
- The underlying salary calculations continue to occur every second to maintain accuracy.
- This change decouples the UI update frequency from the calculation frequency, providing a smoother and less "jumpy" visual experience for these specific displays.
- The "Time Until Next Payday" countdown display continues to update every second, as is typical for countdown timers.